### PR TITLE
Replace raw domain to githubusercontent.com

### DIFF
--- a/gfwlist2privoxy
+++ b/gfwlist2privoxy
@@ -20,7 +20,7 @@ temporary_file=$(mktemp)
 base64 -d       </dev/null &>/dev/null && base64='base64 -d'
 base64 --decode </dev/null &>/dev/null && base64='base64 --decode'
 [ "$base64" ] || { echo "[ERR] Command not found: 'base64'" 1>&2; exit 1; }
-curl -4sSkL https://raw.github.com/gfwlist/gfwlist/master/gfwlist.txt | $base64 | perl -pe '
+curl -4sSkL https://raw.githubusercontent.com/gfwlist/gfwlist/master/gfwlist.txt | $base64 | perl -pe '
 if (/URL Keywords/i) { $null = <> until $null =~ /^!/ }
 s#^\s*+$|^!.*+$|^@@.*+$|^\[AutoProxy.*+$|^/.*/$##i;
 s@^\|\|?|\|$@@;


### PR DESCRIPTION
`raw.github.com` has been changed to `githubusercontent.com`  https://developer.github.com/changes/2014-04-25-user-content-security/